### PR TITLE
favicon for IPFS publish: load from local path + catch null icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@webrecorder/awp-sw",
   "browser": "dist/sw.js",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "main": "index.js",
   "type": "module",
   "repository": {
@@ -18,7 +18,7 @@
   "dependencies": {
     "@ipld/car": "^5.1.1",
     "@ipld/unixfs": "^2.1.1",
-    "@webrecorder/wabac": "^2.16.1",
+    "@webrecorder/wabac": "^2.16.2",
     "auto-js-ipfs": "^2.3.0",
     "client-zip": "^2.3.0",
     "hash-wasm": "^4.9.0",

--- a/src/ipfsutils.js
+++ b/src/ipfsutils.js
@@ -80,7 +80,7 @@ export async function ipfsAdd(coll, downloaderOpts = {}, replayOpts = {}, progre
 
   if (coll.config && coll.config.metadata && coll.config.metadata.size) {
     totalSize = coll.config.metadata.size +
-    swContent.length + uiContent.length + favicon.length + htmlContent.length;
+    swContent.length + uiContent.length + (favicon ? favicon.length : 0) + htmlContent.length;
   }
 
   progress(0, totalSize);

--- a/src/ipfsutils.js
+++ b/src/ipfsutils.js
@@ -63,13 +63,15 @@ export async function ipfsAdd(coll, downloaderOpts = {}, replayOpts = {}, progre
     UnixFS.withCapacity(capacity)
   );
 
-  const swContent = await fetchBuffer("sw.js", replayOpts.replayBaseUrl || self.location.href);
-  const uiContent = await fetchBuffer("ui.js", replayOpts.replayBaseUrl || self.location.href);
+  const baseUrl = replayOpts.replayBaseUrl || self.location.href;
+
+  const swContent = await fetchBuffer("sw.js", baseUrl);
+  const uiContent = await fetchBuffer("ui.js", baseUrl);
 
   let favicon = null;
 
   try {
-    favicon = await fetchBuffer("https://replayweb.page/build/icon.png");
+    favicon = await fetchBuffer("icon.png", baseUrl);
   } catch (e) {
     console.warn("Couldn't load favicon");
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -512,10 +512,10 @@
   resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-2.0.0.tgz#f08ea194e01ed45379383a8886e8c85a65a5f26a"
   integrity sha512-Rumq5mHvGXamnOh3O8yLk1sjx8dB30qF1OeR6VC00DIR6SLJ4bwwUGKC4pE7qBFoQyyh0H9sAg3fikYgAqVR0w==
 
-"@webrecorder/wabac@^2.16.1":
-  version "2.16.1"
-  resolved "https://registry.yarnpkg.com/@webrecorder/wabac/-/wabac-2.16.1.tgz#85c0bab4d45975d8ecfbdb57e5735a093b728410"
-  integrity sha512-sd2t96hEgDo2eP9M2nA4jYP0bFh3cslncvjrOC+5QnE2cpoEqyfZv6dm8dkhaAy0toOhwLzbbhzLaTb5kkh63g==
+"@webrecorder/wabac@^2.16.2":
+  version "2.16.2"
+  resolved "https://registry.yarnpkg.com/@webrecorder/wabac/-/wabac-2.16.2.tgz#0e224d62e63aeada25ec542635b0bab5f36869b5"
+  integrity sha512-duTfM2EEvSb9ytZDkAB6zOwR1/EtmtJaMNyIgwnTDkvPWyMAEoD3M5LGshNW9W3igVJLwZVbJ7C9j63PAFDiMQ==
   dependencies:
     "@peculiar/asn1-ecc" "^2.3.4"
     "@peculiar/asn1-schema" "^2.3.3"


### PR DESCRIPTION
Don't fail if no favicon found, also load from local path instead of hardcoded remote URL
update to latest wabac.js
bump to 0.3.1