### PR TITLE
IPFS fail notify

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@webrecorder/awp-sw",
   "browser": "dist/sw.js",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "main": "index.js",
   "type": "module",
   "repository": {

--- a/src/api.js
+++ b/src/api.js
@@ -134,6 +134,12 @@ class ExtAPI extends API
       event.waitUntil(p);
     }
 
+    try {
+      await p;
+    } catch (e) {
+      return {error: "ipfs_not_available"};
+    }
+
     return {collId};
   }
 


### PR DESCRIPTION
Better notification when IPFS pin/unpin fails
- Return 404 from pin endpoint
- Return removed: false when unpinning
- Clear cached autoipfs config when failed
bump to 0.3.2