### PR TITLE
recproxy: use response.url instead of request.url as response.url sho…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@webrecorder/awp-sw",
   "browser": "dist/sw.js",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "main": "index.js",
   "type": "module",
   "repository": {

--- a/src/recproxy.js
+++ b/src/recproxy.js
@@ -64,7 +64,7 @@ export class RecProxy extends ArchiveDB
 
     // don't record content proxied from specified hosts
     if (!this.recordProxied && this.liveProxy.hostProxy) {
-      const parsedUrl = new URL(request.url);
+      const parsedUrl = new URL(response.url);
       if (this.liveProxy.hostProxy[parsedUrl.host]) {
         await this.decCounter();
         return response;


### PR DESCRIPTION
…uld be resolved to valid url, while request.url may be

scheme-relative
bump to 0.3.3